### PR TITLE
Mark eslint 4 as supported as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/vuejs/eslint-plugin-vue-libs#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "eslint-plugin-html": "^2.0.0"


### PR DESCRIPTION
I noticed no problem using this plugin with eslint 4