### PR TITLE
Breaking: upgrade eslint-plugin-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "homepage": "https://github.com/vuejs/eslint-plugin-vue-libs#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "eslint": "^4.7.0"
   },
   "dependencies": {
-    "eslint-plugin-html": "^2.0.0"
+    "eslint-plugin-html": "^4.0.1"
   }
 }


### PR DESCRIPTION
Fixes #3.

This PR upgrade `eslint-plugin-html` to the latest version. It avoids an error with using ESLint 4.x:

    eslint-plugin-html error: It seems that eslint is not loaded. If you think it is a bug, please file a report at https://github.com/BenoitZugmeyer/eslint-plugin-html/issues

This is a breaking change because the latest `eslint-plugin-html` supports only `eslint@>=4.7.0`.